### PR TITLE
Pass Params and Search instead of context

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,18 @@ view: (params, search) => html`
 
 ### Multiple Route Loaders
 
-It is encouraged that you use a src folder structure like this.
+If that application you are building has many sub application it may be beneficial to organize your source folder like so.
 
 ```
 /src
 | /components
 |
-| /page1
-| | page1-view.js
+| /app1
+| | app1-view.js
 | | route-loader.js
 |
-| /page2
-| | page2-view.js
+| /app2
+| | app2-view.js
 | | route-loader.js
 |
 | entry-point.js
@@ -82,8 +82,8 @@ The main route-loader in the root of the src folder should import the route-load
 
 ```js
 /* src/route-loader.js */
-import { loader as page1Loader } from './page1/route-loader.js';
-import { loader as page2Loader } from './page2/route-loader.js';
+import { loader as app1Loader } from './app1/route-loader.js';
+import { loader as app2Loader } from './app2/route-loader.js';
 import { registerRoute } from '@brightspaceui-labs/router.js';
 
 registerRoute([
@@ -91,16 +91,16 @@ registerRoute([
         pattern: '/',
         view: () => html`<entry-point></entry-point>`
     },
-    page1Loader,
-    page2Loader
+    app1Loader,
+    app2Loader
 ])
 
 /* src/page1/route-loader.js */
 export const loader () => [
     {
-        pattern: '/page1',
-        loader: () => import('./page1-view.js'),
-        view: () => html`<page-1></page-1>`
+        pattern: '/app1',
+        loader: () => import('./app1-view.js'),
+        view: () => html`<app-1></app-1>`
     }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ registerRoute([
 ])
 
 /* src/page1/route-loader.js */
-export const () => [
+export const loader () => [
     {
         pattern: '/page1',
         loader: () => import('./page1-view.js'),

--- a/README.md
+++ b/README.md
@@ -58,6 +58,62 @@ view: (params, search) => html`
     </user-view>` 
 ```
 
+### Multiple Route Loaders
+
+It is encouraged that you use a src folder structure like this.
+
+```
+/src
+| /components
+|
+| /page1
+| | page1-view.js
+| | route-loader.js
+|
+| /page2
+| | page2-view.js
+| | route-loader.js
+|
+| entry-point.js
+| route-loader.js
+```
+
+The main route-loader in the root of the src folder should import the route-loader files in the subdirectories that separate the apps pages. It should look something like this.
+
+```js
+/* src/route-loader.js */
+import { loader as page1Loader } from './page1/route-loader.js';
+import { loader as page2Loader } from './page2/route-loader.js';
+import { registerRoute } from '@brightspaceui-labs/router.js';
+
+registerRoute([
+    {
+        pattern: '/',
+        view: () => html`<entry-point></entry-point>`
+    },
+    page1Loader,
+    page2Loader
+])
+
+/* src/page1/route-loader.js */
+export const () => [
+    {
+        pattern: '/page1',
+        loader: () => import('./page1-view.js'),
+        view: () => html`<page-1></page-1>`
+    }
+]
+```
+
+Route-loaders can be nested as far as you would like. You could have a folder path `/src/user/settings/profile/password` and have route-loaders at each point that import the next route-loader one level above. Therefore, 
+
+`/user/route-loader.js` could import and register   
+`/user/settings/route-loader.js` which in turn imports and registers   
+`/user/settings/profile/route-loaders.js`.
+
+and on and on...
+
+
 ## RouteReactor
 The RouteReactor is an early Reactive Controller that updates an element when the current route changes.
 

--- a/README.md
+++ b/README.md
@@ -35,31 +35,12 @@ This is the first step. Registering routes builds the routing tree that the appl
 The view is also passed the url parameters and search object. For example:
 
 ```js 
-pattern: '/user/:id/:page'
-view: (params) => html`<user-view id=${params.id} page=${params.page}></user-view>` 
-```
-
-A `URLSearchParameters` object is always the last parameter of the view function:
-
-```js 
-pattern: '/user' // search: ?id=1&page=1&semester=1
-view: (_, search) => html`
-    <user-view 
-        ?id=${search.id} 
-        ?page=${search.page)} 
-        ?semester=${search.semester}>
-    </user-view>` 
-```
-
-They can also be used together:
-
-```js 
 pattern: '/user/:id/:page' // search: ?semester=1
 view: (params, search) => html`
     <user-view 
-        id=${params.id} 
+        id=${params.id}
         page=${params.page} 
-        ?semester=${search.semester}>
+        semester=${search.semester}> 
     </user-view>` 
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,17 @@ registerRoutes([
         loader: () => import('./home.js'),
         view: () => html`<test-home></test-home>`
     },
-    peopleRouteLoader,
-    placesRouteLoader,
+    {
+        pattern: '/example/:id',
+        view: id => html`<test-id id=${id}></test-id>`
+    },
+    {
+        pattern: '/example/foo/:bar',
+        view: (bar, search) => html`
+            <test-foo bar=${bar}>
+                ${search.name}
+            </test-foo>`
+    }
     {
         pattern: '*',
         view: (ctx) => html`<h1>Not Found ${ctx.pathName}</h1>`
@@ -23,7 +32,36 @@ registerRoutes([
 
 This is the first step. Registering routes builds the routing tree that the application uses to determine which view to show at the entry-point. A routes view is a function that returns a lit-html template. This template gets rendered into your applications entry-point when the url matches the pattern.
 
-The view is also passed a page context object 
+The view is also passed the url parameters and search object in definition order from left to right. For example:
+
+```js 
+pattern: '/user/:id/:page'
+view: (id, page) => html`<user-view id=${id} page=${page}></user-view>` 
+```
+
+A `URLSearchParameters` object is always the last parameter of the view function:
+
+```js 
+pattern: '/user' // search: ?id=1&page=1&semester=1
+view: (search) => html`
+    <user-view 
+        ?id=${search.id} 
+        ?page=${search.page)} 
+        ?semester=${search.semester}>
+    </user-view>` 
+```
+
+They can also be used together:
+
+```js 
+pattern: '/user/:id/:page' // search: ?semester=1
+view: (id, page, search) => html`
+    <user-view 
+        id=${id} 
+        page=${page} 
+        ?semester=${search.semester}>
+    </user-view>` 
+```
 
 ## RouteReactor
 The RouteReactor is an early Reactive Controller that updates an element when the current route changes.
@@ -52,7 +90,7 @@ class FooBar extends LitElement {
 
     render() {
         let userId = this.route.params.userId;
-        let orgId = this.route.search.get('org-unit');
+        let orgId = this.route.search['org-unit'];
 
         return html`<span> user: ${userId} orgUnit: ${orgId}</span>`;
     }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 A lit-element wrapper around Page.js.
 
-The aim of this library is to provide an easy way to define routes, lazy load the view, and update to changes in the route. 
+The aim of this library is to provide an easy way to define routes, lazy load the view, and update to changes in the route.
+
+> Note: this is a ["labs" component](https://github.com/BrightspaceUI/guide/wiki/Component-Tiers). While functional, these tasks are prerequisites to promotion to BrightspaceUI "official" status:
+>
+> - [ ] [Design organization buy-in](https://github.com/BrightspaceUI/guide/wiki/Before-you-build#working-with-design)
+> - [ ] [design.d2l entry](http://design.d2l/)
+> - [ ] [Architectural sign-off](https://github.com/BrightspaceUI/guide/wiki/Before-you-build#web-component-architecture)
+> - [ ] [Continuous integration](https://github.com/BrightspaceUI/guide/wiki/Testing#testing-continuously-with-travis-ci)
+> - [ ] [Cross-browser testing](https://github.com/BrightspaceUI/guide/wiki/Testing#cross-browser-testing-with-sauce-labs)
+> - [ ] [Unit tests](https://github.com/BrightspaceUI/guide/wiki/Testing#testing-with-polymer-test) (if applicable)
+> - [ ] [Accessibility tests](https://github.com/BrightspaceUI/guide/wiki/Testing#automated-accessibility-testing-with-axe)
+> - [ ] [Visual diff tests](https://github.com/BrightspaceUI/visual-diff)
+> - [ ] [Localization](https://github.com/BrightspaceUI/guide/wiki/Localization) with Serge (if applicable)
+> - [x] Demo page
+> - [ ] README documentation 
 
 ## Route Loading and Registration
 ```js

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ registerRoutes([
     },
     {
         pattern: '/example/:id',
-        view: id => html`<test-id id=${id}></test-id>`
+        view: params => html`<test-id id=${params.id}></test-id>`
     },
     {
         pattern: '/example/foo/:bar',
-        view: (bar, search) => html`
-            <test-foo bar=${bar}>
+        view: (params, search) => html`
+            <test-foo bar=${params.bar}>
                 ${search.name}
             </test-foo>`
     }
     {
         pattern: '*',
-        view: (ctx) => html`<h1>Not Found ${ctx.pathName}</h1>`
+        view: () => html`<h1>Not Found</h1>`
     },
 ], options // the router configurations);
 ```
@@ -36,14 +36,14 @@ The view is also passed the url parameters and search object in definition order
 
 ```js 
 pattern: '/user/:id/:page'
-view: (id, page) => html`<user-view id=${id} page=${page}></user-view>` 
+view: (params) => html`<user-view id=${params.id} page=${params.page}></user-view>` 
 ```
 
 A `URLSearchParameters` object is always the last parameter of the view function:
 
 ```js 
 pattern: '/user' // search: ?id=1&page=1&semester=1
-view: (search) => html`
+view: (_, search) => html`
     <user-view 
         ?id=${search.id} 
         ?page=${search.page)} 
@@ -55,10 +55,10 @@ They can also be used together:
 
 ```js 
 pattern: '/user/:id/:page' // search: ?semester=1
-view: (id, page, search) => html`
+view: (params, search) => html`
     <user-view 
-        id=${id} 
-        page=${page} 
+        id=${params.id} 
+        page=${params.page} 
         ?semester=${search.semester}>
     </user-view>` 
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ registerRoutes([
 
 This is the first step. Registering routes builds the routing tree that the application uses to determine which view to show at the entry-point. A routes view is a function that returns a lit-html template. This template gets rendered into your applications entry-point when the url matches the pattern.
 
-The view is also passed the url parameters and search object in definition order from left to right. For example:
+The view is also passed the url parameters and search object. For example:
 
 ```js 
 pattern: '/user/:id/:page'

--- a/example/people/route-loader.js
+++ b/example/people/route-loader.js
@@ -7,7 +7,7 @@ export function loader() {
         {
             pattern: '/people',
             loader: () => import('./people.js'),
-            view: search => html` <test-people
+            view: (_, search) => html` <test-people
                 @filter-change="${e =>
                     redirect(`/example/people?filter=${e.detail.value}`)}"
                 filter="${ifDefined(search.filter)}"
@@ -16,7 +16,8 @@ export function loader() {
         {
             pattern: '/people/:id',
             loader: () => import('./person.js'),
-            view: id => html`<test-person person-id="${id}"></test-person>`,
+            view: params =>
+                html`<test-person person-id="${params.id}"></test-person>`,
         },
     ];
 }

--- a/example/people/route-loader.js
+++ b/example/people/route-loader.js
@@ -7,19 +7,16 @@ export function loader() {
         {
             pattern: '/people',
             loader: () => import('./people.js'),
-            view: context => html` <test-people
+            view: search => html` <test-people
                 @filter-change="${e =>
                     redirect(`/example/people?filter=${e.detail.value}`)}"
-                filter="${ifDefined(context.searchParams.filter)}"
+                filter="${ifDefined(search.filter)}"
             ></test-people>`,
         },
         {
             pattern: '/people/:id',
             loader: () => import('./person.js'),
-            view: context =>
-                html`<test-person
-                    person-id="${context.params.id}"
-                ></test-person>`,
+            view: id => html`<test-person person-id="${id}"></test-person>`,
         },
     ];
 }

--- a/example/people/route-loader.js
+++ b/example/people/route-loader.js
@@ -7,17 +7,17 @@ export function loader() {
         {
             pattern: '/people',
             loader: () => import('./people.js'),
-            view: (_, search) => html` <test-people
+            view: ctx => html` <test-people
                 @filter-change="${e =>
                     redirect(`/example/people?filter=${e.detail.value}`)}"
-                filter="${ifDefined(search.filter)}"
+                filter="${ifDefined(ctx.search.filter)}"
             ></test-people>`,
         },
         {
             pattern: '/people/:id',
             loader: () => import('./person.js'),
-            view: params =>
-                html`<test-person person-id="${params.id}"></test-person>`,
+            view: ctx =>
+                html`<test-person person-id="${ctx.params.id}"></test-person>`,
         },
     ];
 }

--- a/example/places/route-loader.js
+++ b/example/places/route-loader.js
@@ -10,7 +10,8 @@ export function loader() {
         {
             pattern: '/places/:id',
             loader: () => import('./place.js'),
-            view: id => html`<test-place place-id="${id}"></test-place>`,
+            view: params =>
+                html`<test-place place-id="${params.id}"></test-place>`,
         },
     ];
 }

--- a/example/places/route-loader.js
+++ b/example/places/route-loader.js
@@ -10,8 +10,7 @@ export function loader() {
         {
             pattern: '/places/:id',
             loader: () => import('./place.js'),
-            view: context =>
-                html`<test-place place-id="${context.params.id}"></test-place>`,
+            view: id => html`<test-place place-id="${id}"></test-place>`,
         },
     ];
 }

--- a/example/places/route-loader.js
+++ b/example/places/route-loader.js
@@ -10,8 +10,8 @@ export function loader() {
         {
             pattern: '/places/:id',
             loader: () => import('./place.js'),
-            view: params =>
-                html`<test-place place-id="${params.id}"></test-place>`,
+            view: ctx =>
+                html`<test-place place-id="${ctx.params.id}"></test-place>`,
         },
     ];
 }

--- a/src/router.js
+++ b/src/router.js
@@ -6,10 +6,12 @@ let _lastOptions = {};
 
 const _handleRouteView = (context, next, r) => {
     if (r.view) {
-        context.view = r.view.apply(null, [
-            context.params,
-            context.searchParams,
-        ]);
+        const reducedContext = {
+            params: context.params,
+            search: context.searchParams,
+            path: context.pathname,
+        };
+        context.view = r.view(reducedContext);
         context.handled = true;
 
         next();

--- a/src/router.js
+++ b/src/router.js
@@ -6,14 +6,10 @@ let _lastOptions = {};
 
 const _handleRouteView = (context, next, r) => {
     if (r.view) {
-        const paramKeys = context.routePath
-            .split('/')
-            .filter(part => part.charAt(0) === ':')
-            .map(key => key.substr(1));
-
-        const params = paramKeys.map(key => context.params[key]);
-
-        context.view = r.view.apply(null, [...params, context.searchParams]);
+        context.view = r.view.apply(null, [
+            context.params,
+            context.searchParams,
+        ]);
         context.handled = true;
 
         next();

--- a/src/router.js
+++ b/src/router.js
@@ -6,8 +6,16 @@ let _lastOptions = {};
 
 const _handleRouteView = (context, next, r) => {
     if (r.view) {
-        context.view = r.view(context);
+        const paramKeys = context.routePath
+            .split('/')
+            .filter(part => part.charAt(0) === ':')
+            .map(key => key.substr(1));
+
+        const params = paramKeys.map(key => context.params[key]);
+
+        context.view = r.view.apply(null, [...params, context.searchParams]);
         context.handled = true;
+
         next();
     } else {
         next();

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -31,8 +31,12 @@ const initRouter = () => {
             },
             {
                 pattern: '/param/:foo/:bar',
-                view: (foo, bar, search) =>
-                    html`<p>${foo}, ${bar}, ${search.test}</p>`,
+                view: (params, search) =>
+                    html`<p>${params.foo}, ${params.bar}, ${search.test}</p>`,
+            },
+            {
+                pattern: '/search',
+                view: (_, search) => html`<p>${search.test}</p>`,
             },
             load1,
             load2,
@@ -131,5 +135,12 @@ describe('Router', () => {
         await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
         const p = entryPoint.shadowRoot.querySelector('p').innerText;
         expect(p).to.eql('zip, zap, zop');
+    });
+
+    it('Should pass a search parameter without any url params', async () => {
+        redirect('/search?test=test');
+        await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
+        const p = entryPoint.shadowRoot.querySelector('p').innerText;
+        expect(p).to.eql('test');
     });
 });

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -31,12 +31,14 @@ const initRouter = () => {
             },
             {
                 pattern: '/param/:foo/:bar',
-                view: (params, search) =>
-                    html`<p>${params.foo}, ${params.bar}, ${search.test}</p>`,
+                view: ctx =>
+                    html`<p>
+                        ${ctx.params.foo}, ${ctx.params.bar}, ${ctx.search.test}
+                    </p>`,
             },
             {
                 pattern: '/search',
-                view: (_, search) => html`<p>${search.test}</p>`,
+                view: ctx => html`<p>${ctx.search.test}</p>`,
             },
             load1,
             load2,

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -123,14 +123,14 @@ describe('Router', () => {
         );
     });
 
-    it('Should pass parameters in left-to-right', async () => {
+    it('Should pass parameters', async () => {
         redirect('/param/beep/boop');
         await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
         const p = entryPoint.shadowRoot.querySelector('p').innerText;
         expect(p).to.eql('beep, boop,');
     });
 
-    it('Should pass parameters in left-to-right with search param at the end', async () => {
+    it('Should pass parameters with search param at the end', async () => {
         redirect('/param/zip/zap?test=zop');
         await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
         const p = entryPoint.shadowRoot.querySelector('p').innerText;

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -29,6 +29,11 @@ const initRouter = () => {
                 pattern: '/param/:test',
                 view: () => html`<route-view></route-view>`,
             },
+            {
+                pattern: '/param/:foo/:bar',
+                view: (foo, bar, search) =>
+                    html`<p>${foo}, ${bar}, ${search.test}</p>`,
+            },
             load1,
             load2,
         ],
@@ -112,5 +117,19 @@ describe('Router', () => {
         expect(paramQueryEl.shadowRoot.querySelector('p').innerText).to.equal(
             'Param test: hello, Search Test: hello'
         );
+    });
+
+    it('Should pass parameters in left-to-right', async () => {
+        redirect('/param/beep/boop');
+        await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
+        const p = entryPoint.shadowRoot.querySelector('p').innerText;
+        expect(p).to.eql('beep, boop,');
+    });
+
+    it('Should pass parameters in left-to-right with search param at the end', async () => {
+        redirect('/param/zip/zap?test=zop');
+        await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
+        const p = entryPoint.shadowRoot.querySelector('p').innerText;
+        expect(p).to.eql('zip, zap, zop');
     });
 });


### PR DESCRIPTION
I think this is the last place we were using the page context. This should introduce enough isolation that if we ever need to we can abandon page.js

Quality Notes

### Testing
 - [x] Test parameters are available in the view
 - [x] Test search params are available in the view 
 - [x] Test both are available

### Documentation

Updated the readme to demonstrate param and search passing to the view function.

FYI: @anhill-D2L @johngwilkinson  @bemailloux 