### PR TITLE
Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: Release
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: Brightspace/third-party-actions@actions/checkout
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        uses: Brightspace/third-party-actions@actions/setup-node
+      - name: Semantic Release
+        uses: BrightspaceUI/actions/semantic-release@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+          NPM: true
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
-  "author": "",
-  "name": "d2l-router",
+  "author": "D2L Corporation",
+  "license": "Apache-2.0",
+  "name": "@brightspace-ui-labs/router",
   "description": "",
   "main": "index.js",
+  "repository": "https://github.com/BrightspaceUILabs/router.git",
   "scripts": {
     "test": "web-test-runner --coverage",
     "lint": "eslint --ext .js,.html . --ignore-path .gitignore && prettier \"**/*.js\" --check --ignore-path .gitignore",
@@ -14,7 +16,6 @@
     "start": "web-dev-server --node-resolve --open --watch --app-index example/index.html"
   },
   "version": "1.0.0",
-  "license": "ISC",
   "dependencies": {
     "@brightspace-ui/core": "^1.131.2",
     "@open-wc/dedupe-mixin": "^1.3.0",
@@ -52,5 +53,12 @@
       "eslint --fix",
       "prettier --write"
     ]
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "./src/router.js",
+    "./src/RouteReactor.js"
+  ] 
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "D2L Corporation",
   "license": "Apache-2.0",
-  "name": "@brightspace-ui-labs/router",
+  "name": "@brightspace-ui-labs/lit-router",
   "description": "",
   "main": "index.js",
   "repository": "https://github.com/BrightspaceUILabs/router.git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier:write": "prettier \"**/*.js\" --write --ignore-path .gitignore",
     "start": "web-dev-server --node-resolve --open --watch --app-index example/index.html"
   },
-  "version": "1.0.0",
+  "version": "0.1.0",
   "dependencies": {
     "@brightspace-ui/core": "^1.131.2",
     "@open-wc/dedupe-mixin": "^1.3.0",


### PR DESCRIPTION
A release action for publishing the router to npm. 

This will begin publishing under version 0.1.1 as a beta release with an api that may change in the future. However, I feel that this helper is in a state that other projects, such as the AQ Dashboard, can use this without too much difficulty.

