### PR TITLE
Pass Entry Point Value To View

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ This is the first step. Registering routes builds the routing tree that the appl
 The view is given a context object that contains:
  - params: The URL parameters
  - search: The Search Query values
- - entry: An object passed by the entry-point. It is `undefined` if given nothing.
+ - options: An object passed by the entry-point. It is an empty object if given nothing.
 
 ```js 
 pattern: '/user/:id/:page' // search: ?semester=1
 view: ctx => html`
     <user-view 
-        id=${ctx.params.id}
+        id=${ctx.options.id}
         page=${ctx.params.page} 
         semester=${ctx.search.semester}> 
     </user-view>` 
@@ -128,8 +128,8 @@ class EntryPoint extends LitElement {
     }
 
     render() {
-        const entry = { /* Values to pass to the views */};
-        return this.route.renderView(entry);
+        const options = { /* Options for the views. Can be used for attributes */};
+        return this.route.renderView(options);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ registerRoutes([
     },
     {
         pattern: '/example/:id',
-        view: params => html`<test-id id=${params.id}></test-id>`
+        view: ctx => html`<test-id id=${ctx.params.id}></test-id>`
     },
     {
         pattern: '/example/foo/:bar',
-        view: (params, search) => html`
-            <test-foo bar=${params.bar}>
-                ${search.name}
+        view: (ctx) => html`
+            <test-foo bar=${ctx.params.bar}>
+                ${ctx.search.name}
             </test-foo>`
     }
     {
@@ -46,15 +46,18 @@ registerRoutes([
 
 This is the first step. Registering routes builds the routing tree that the application uses to determine which view to show at the entry-point. A routes view is a function that returns a lit-html template. This template gets rendered into your applications entry-point when the url matches the pattern.
 
-The view is also passed the url parameters and search object. For example:
+The view is given a context object that contains:
+ - params: The URL parameters
+ - search: The Search Query values
+ - entry: An object passed by the entry-point. It is `undefined` if given nothing.
 
 ```js 
 pattern: '/user/:id/:page' // search: ?semester=1
-view: (params, search) => html`
+view: ctx => html`
     <user-view 
-        id=${params.id}
-        page=${params.page} 
-        semester=${search.semester}> 
+        id=${ctx.params.id}
+        page=${ctx.params.page} 
+        semester=${ctx.search.semester}> 
     </user-view>` 
 ```
 
@@ -125,7 +128,8 @@ class EntryPoint extends LitElement {
     }
 
     render() {
-        return this.route.view;
+        const entry = { /* Values to pass to the views */};
+        return this.route.view(entry);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ class EntryPoint extends LitElement {
 
     render() {
         const entry = { /* Values to pass to the views */};
-        return this.route.view(entry);
+        return this.route.renderView(entry);
     }
 }
 ```

--- a/RouteReactor.js
+++ b/RouteReactor.js
@@ -4,13 +4,13 @@ import { ContextReactor } from './router.js';
 export class RouteReactor extends ContextReactor {
     constructor(host) {
         super(host, ctx => {
-            this.view = ctx.view;
+            this.renderView = ctx.view;
             this.path = ctx.path;
             this.params = ctx.params;
             this.search = ctx.searchParams;
         });
         super.init();
 
-        this.view = () => {};
+        this.renderView = () => {};
     }
 }

--- a/RouteReactor.js
+++ b/RouteReactor.js
@@ -4,7 +4,7 @@ import { ContextReactor } from './router.js';
 export class RouteReactor extends ContextReactor {
     constructor(host) {
         super(host, ctx => {
-            this.renderView = ctx.view;
+            this.renderView = ctx.view ? ctx.view : () => {};
             this.path = ctx.path;
             this.params = ctx.params;
             this.search = ctx.searchParams;

--- a/RouteReactor.js
+++ b/RouteReactor.js
@@ -10,5 +10,7 @@ export class RouteReactor extends ContextReactor {
             this.search = ctx.searchParams;
         });
         super.init();
+
+        this.view = () => {};
     }
 }

--- a/example/app.js
+++ b/example/app.js
@@ -35,7 +35,7 @@ export class App extends LitElement {
                     </ul>
                 </nav>
             </aside>
-            <main>${this.route.view}</main>
+            <main>${this.route.view()}</main>
         `;
     }
 }

--- a/example/app.js
+++ b/example/app.js
@@ -35,7 +35,7 @@ export class App extends LitElement {
                     </ul>
                 </nav>
             </aside>
-            <main>${this.route.view()}</main>
+            <main>${this.route.renderView()}</main>
         `;
     }
 }

--- a/router.js
+++ b/router.js
@@ -10,10 +10,10 @@ const _handleRouteView = (context, next, r) => {
             params: context.params,
             search: context.searchParams,
             path: context.pathname,
-            entry: {},
+            options: {},
         };
-        context.view = entryData => {
-            reducedContext.entry = entryData;
+        context.view = options => {
+            reducedContext.options = options || {};
             return r.view(reducedContext);
         };
         context.handled = true;

--- a/router.js
+++ b/router.js
@@ -10,8 +10,12 @@ const _handleRouteView = (context, next, r) => {
             params: context.params,
             search: context.searchParams,
             path: context.pathname,
+            entry: {},
         };
-        context.view = r.view(reducedContext);
+        context.view = entryData => {
+            reducedContext.entry = entryData;
+            return r.view(reducedContext);
+        };
         context.handled = true;
 
         next();

--- a/test/helpers/main-view.js
+++ b/test/helpers/main-view.js
@@ -2,13 +2,21 @@ import { LitElement } from 'lit-element';
 import { RouteReactor } from '../../RouteReactor.js';
 
 class MainView extends LitElement {
+    static get properties() {
+        return {
+            'main-prop': { type: String, attribute: true },
+        };
+    }
+
     constructor() {
         super();
         this.route = new RouteReactor(this);
     }
 
     render() {
-        return this.route.view;
+        return this.route.view
+            ? this.route.view({ main: this['main-prop'] })
+            : '';
     }
 }
 

--- a/test/helpers/main-view.js
+++ b/test/helpers/main-view.js
@@ -14,8 +14,8 @@ class MainView extends LitElement {
     }
 
     render() {
-        return this.route.view
-            ? this.route.view({ main: this['main-prop'] })
+        return this.route.renderView
+            ? this.route.renderView({ main: this['main-prop'] })
             : '';
     }
 }

--- a/test/helpers/main-view.js
+++ b/test/helpers/main-view.js
@@ -14,9 +14,7 @@ class MainView extends LitElement {
     }
 
     render() {
-        return this.route.renderView
-            ? this.route.renderView({ main: this['main-prop'] })
-            : '';
+        return this.route.renderView({ main: this['main-prop'] });
     }
 }
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -46,7 +46,7 @@ const initRouter = () => {
             },
             {
                 pattern: '/entry-prop',
-                view: ctx => html`<p>${ctx.entry.main}</p>`,
+                view: ctx => html`<p>${ctx.options.main}</p>`,
             },
             load1,
             load2,

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -44,6 +44,10 @@ const initRouter = () => {
                 pattern: '/search',
                 view: ctx => html`<p>${ctx.search.test}</p>`,
             },
+            {
+                pattern: '/entry-prop',
+                view: ctx => html`<p>${ctx.entry.main}</p>`,
+            },
             load1,
             load2,
         ],
@@ -54,7 +58,9 @@ const initRouter = () => {
 describe('Router', () => {
     beforeEach(async () => {
         initRouter();
-        entryPoint = await fixture(html`<main-view></main-view>`);
+        entryPoint = await fixture(
+            html`<main-view main-prop="Passed"></main-view>`
+        );
         redirect('/');
     });
 
@@ -157,5 +163,13 @@ describe('Router', () => {
         const p = entryPoint.shadowRoot.querySelector('p').innerText;
         expect(p).to.equal('User');
         expect(window.location.pathname).to.include('/user');
+    });
+
+    it('Should receive passed values from entry-point', async () => {
+        redirect('/entry-prop');
+        await entryPoint.updateComplete;
+        await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
+        const p = entryPoint.shadowRoot.querySelector('p').innerText;
+        expect(p).to.equal('Passed');
     });
 });

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -84,6 +84,7 @@ describe('Router', () => {
     });
 
     it('Should change the route on redirect', async () => {
+        await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
         let p = entryPoint.shadowRoot.querySelector('p').innerText;
         expect(p).to.equal('Index');
 
@@ -96,6 +97,7 @@ describe('Router', () => {
     });
 
     it('Should load routes from separate files', async () => {
+        await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
         redirect('/load1');
         await waitUntil(
             () =>
@@ -159,7 +161,9 @@ describe('Router', () => {
     it('Should redirect', async () => {
         redirect('/redirect');
         await entryPoint.updateComplete;
-        await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
+        await waitUntil(
+            () => entryPoint.shadowRoot.querySelector('p') !== null
+        );
         const p = entryPoint.shadowRoot.querySelector('p').innerText;
         expect(p).to.equal('User');
         expect(window.location.pathname).to.include('/user');
@@ -168,7 +172,9 @@ describe('Router', () => {
     it('Should receive passed values from entry-point', async () => {
         redirect('/entry-prop');
         await entryPoint.updateComplete;
-        await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
+        await waitUntil(
+            () => entryPoint.shadowRoot.querySelector('p') !== null
+        );
         const p = entryPoint.shadowRoot.querySelector('p').innerText;
         expect(p).to.equal('Passed');
     });


### PR DESCRIPTION
Adds a way to pass entry-point properties or other shared data to the page views. 

Example

```js
// entry-point.js
class EntryPoint extends Lit-Element {
  static get properties() {
    return {
      isDemo: ...
      showChart: ...
      ...
    }
  }
  
  render() {
    let properties = { /* values to pass to views */};
    // pass a property object into the view function
    return this.router.view(properties)
  }
}

// route-loader.js

registerRoute([
  {
    pattern: '/',
    // get it back again in the view context
    view: (ctx) => html`<dashboard-view isDemo=${ctx.entry.isDemo}></dashboard-view>`
  }
]);
```

API changes

- Makes the `RouteReactor` `view` property a function.
- Adds `entry` to the view context.
- redirects return no view which is not an issue as the page is redirecting.

Quality Notes

Testing
 - [x] Verify that passed parameters are accessible by view elements.
 
 Documentation
  - [x] Update Readme
  - [x] Update Demo
