### PR TITLE
ContextReactor should not call requestUpdate for unknown routes. This…

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   },
   "version": "1.0.9",
   "dependencies": {
+    "lit-element": "^2.5.1",
+    "lit-html": "^1.4.1",
     "page": "^1.11.6"
   },
   "devDependencies": {
@@ -32,8 +34,6 @@
     "karma": "^5.2.3",
     "karma-sauce-launcher": "^4.3.6",
     "lint-staged": "^10.5.4",
-    "lit-element": "^2.5.1",
-    "lit-html": "^1.4.1",
     "prettier": "^2.2.1"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
   },
   "version": "1.0.9",
   "dependencies": {
-    "lit-element": "^2.5.1",
-    "lit-html": "^1.4.1",
     "page": "^1.11.6"
   },
   "devDependencies": {
@@ -34,6 +32,8 @@
     "karma": "^5.2.3",
     "karma-sauce-launcher": "^4.3.6",
     "lint-staged": "^10.5.4",
+    "lit-element": "^2.5.1",
+    "lit-html": "^1.4.1",
     "prettier": "^2.2.1"
   },
   "prettier": {

--- a/router.js
+++ b/router.js
@@ -115,7 +115,8 @@ export class ContextReactor {
             addMiddleware(ctx => {
                 ContextReactor.listeners.forEach(listener => {
                     listener.callback(ctx);
-                    if (listener.host) {
+                    // call requestUpdate only for known routes when ctx.handled is truthy
+                    if (listener.host && ctx.handled) {
                         listener.host.requestUpdate();
                     }
                 });

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-return-assign */
 /* eslint-disable no-new */
-import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, waitUntil } from '@open-wc/testing';
 import { registerRoutes, redirect, RouterTesting } from '../router.js';
 import { loader as load1 } from './helpers/route-loader-1.js';
 import { loader as load2 } from './helpers/route-loader-2.js';
@@ -161,6 +161,7 @@ describe('Router', () => {
     it('Should redirect', async () => {
         redirect('/redirect');
         await entryPoint.updateComplete;
+        await aTimeout(50);
         await waitUntil(
             () => entryPoint.shadowRoot.querySelector('p') !== null
         );


### PR DESCRIPTION
ContextReactor should not call `requestUpdate` for unknown routes. This could lead to a rendering of a blank page when a user leaves SPA

[DE46038](https://rally1.rallydev.com/#/?detail=/defect/614623664091&fdp=true): AQD: Clicking "Back to Insights Portal" causes blank page with "Back to AQD" to appear briefly

* Functional Testing 
  * [x] Browsers (Chrome, FF, Edge)
  * [x] Test cases
     * [x] Clicking "Back to Insights Portal" opens "Insights Portal" after some delay. 
     * [x] Other navigation in AQD works as expected
* Security, devops, perf: N/A
* UX and docs
  * [x] Demo
  
FYI @Brightspace/draco-vis