### PR TITLE
Add host as this to view

### DIFF
--- a/RouteReactor.js
+++ b/RouteReactor.js
@@ -10,9 +10,7 @@ export class RouteReactor extends ContextReactor {
                 this[ctxKey] = reduced[ctxKey];
             });
 
-            this.renderView = ctx.view
-                ? opts => ctx.view(host, opts)
-                : () => {};
+            this.renderView = opts => ctx.view?.(host, opts)
 
             // this.path = ctx.pathname;
             // this.params = ctx.params;

--- a/RouteReactor.js
+++ b/RouteReactor.js
@@ -10,7 +10,7 @@ export class RouteReactor extends ContextReactor {
                 this[ctxKey] = reduced[ctxKey];
             });
 
-            this.renderView = opts => ctx.view?.(host, opts)
+            this.renderView = opts => ctx.view?.(host, opts);
 
             // this.path = ctx.pathname;
             // this.params = ctx.params;

--- a/RouteReactor.js
+++ b/RouteReactor.js
@@ -10,7 +10,9 @@ export class RouteReactor extends ContextReactor {
                 this[ctxKey] = reduced[ctxKey];
             });
 
-            this.renderView = ctx.view ? ctx.view : () => {};
+            this.renderView = ctx.view
+                ? opts => ctx.view(host, opts)
+                : () => {};
 
             // this.path = ctx.pathname;
             // this.params = ctx.params;

--- a/router.js
+++ b/router.js
@@ -26,9 +26,9 @@ const _storeCtx = () => {
 const _handleRouteView = (context, next, r) => {
     if (r.view) {
         const reducedContext = _createReducedContext(context);
-        context.view = options => {
+        context.view = (host, options) => {
             reducedContext.options = options || {};
-            return r.view(reducedContext);
+            return r.view.call(host, reducedContext);
         };
         context.handled = true;
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -48,6 +48,12 @@ const initRouter = () => {
                 pattern: '/entry-prop',
                 view: ctx => html`<p>${ctx.options.main}</p>`,
             },
+            {
+                pattern: '/entry-this',
+                view() {
+                    return html`<p>${this['main-prop']}</p>`;
+                },
+            },
             load1,
             load2,
         ],
@@ -172,6 +178,16 @@ describe('Router', () => {
 
     it('Should receive passed values from entry-point', async () => {
         redirect('/entry-prop');
+        await entryPoint.updateComplete;
+        await waitUntil(
+            () => entryPoint.shadowRoot.querySelector('p') !== null
+        );
+        const p = entryPoint.shadowRoot.querySelector('p').innerText;
+        expect(p).to.equal('Passed');
+    });
+
+    it('Should receive entry-point as this', async () => {
+        redirect('/entry-this');
         await entryPoint.updateComplete;
         await waitUntil(
             () => entryPoint.shadowRoot.querySelector('p') !== null


### PR DESCRIPTION
Instead of pre-constructing `options` to pass to each view, this allows each view to take what it needs from the host.