### PR TITLE
Add route options to readme and document the redirect feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ registerRoutes([
 
 This is the first step. Registering routes builds the routing tree that the application uses to determine which view to show at the entry-point. A routes view is a function that returns a lit-html template. This template gets rendered into your applications entry-point when the url matches the pattern.
 
+### Route options
+
+Each route must be registered as an object with these properties:
+- pattern (required): The Page.js route pattern on which to match
+- loader (optional): Initial loading to perform before rendering the view; must return a Promise
+- view (optional): Function that returns a lit-html template to render
+- to (optional): String indicating a redirect path, using Page.js `redirect(fromPath, toPath)`
+
+### View context
+
 The view is given a context object that contains:
  - params: The URL parameters.
  - search: The Search Query values.


### PR DESCRIPTION
Adding some documentation about the route options, specifically the undocumented `to` option that allows redirects! Today I was wondering if this router supported redirects and I found the answer was yes:
https://github.com/BrightspaceUILabs/router/commit/cf40e23d925e6f0d9a50f7626d89e40c88457e43
