### PR TITLE
Fix issue with matching multiple routes

### DIFF
--- a/router.js
+++ b/router.js
@@ -39,13 +39,25 @@ const _handleRouteView = (context, next, r) => {
 };
 
 const _handleRouteLoader = r => (context, next) => {
+    const enableRouteOrderFix = _lastOptions?.enableRouteOrderFix ?? false;
+
+    // Skip further pattern matches if the route has already been handled
+    if (enableRouteOrderFix && context.handled) {
+        next();
+        return;
+    }
+
     if (r.loader) {
         r.loader().then(() => {
             _handleRouteView(context, next, r);
         });
     } else if (r.pattern && r.to) {
-        activePage.redirect(r.pattern, r.to);
-        next();
+        if (enableRouteOrderFix) {
+            activePage.redirect(r.to);
+        } else {
+            activePage.redirect(r.pattern, r.to);
+            next();
+        }
     } else {
         _handleRouteView(context, next, r);
     }


### PR DESCRIPTION
I was doing some work with the router and ran into this issue again: https://github.com/BrightspaceUILabs/router/issues/36

I decided to dig into it a bit more and I think I figured out why it's happening.

Essentially, the problem comes down to the fact that the router adds a `next()` call after every matched route view/redirect call (see [here](https://github.com/BrightspaceUILabs/router/blob/main/router.js#L35) and [here](https://github.com/BrightspaceUILabs/router/blob/main/router.js#L48)). This tells pagejs to keep trying to match against routes even though it has already found a match. Here's an example of how this works with just pagejs: https://codesandbox.io/p/sandbox/t6ysx6

The reason that the router seems to call `next()` for each matching route is that there are multiple middlewares that are registered after the consumer-defined routes, which means there's a need to have those routes use `next()` so that those middlewares can be matched later in the order of execution (see [here](https://github.com/BrightspaceUILabs/router/blob/main/router.js#L115) and [here](https://github.com/BrightspaceUILabs/router/blob/main/router.js#L96)).

The solution I implemented here is the quickest solution to this. We already track if a consumer-defined route has matched, so just checking that value before executing any further consumer-defined matches should solve the main issue. I also added a fix to the redirect functionality that causes an infinite loop.

Considering that this is a known issue that multiple projects have used a workaround for (i.e. putting the wildcard redirect as the first matching route), we might have to treat this as a breaking change despite being an issue fix. This fix would now make any project that has implemented the workaround always go to their "not found" page regardless of route.