### PR TITLE
feat: have a single entrypoint for exports

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -1,6 +1,6 @@
 import './route-loader.js';
 import { css, html, LitElement } from 'lit';
-import { RouteReactor } from '../RouteReactor.js';
+import { RouteReactor } from '../index.js';
 
 export class App extends LitElement {
 	static get styles() {

--- a/example/people/route-loader.js
+++ b/example/people/route-loader.js
@@ -1,6 +1,6 @@
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { redirect } from '../../router.js';
+import { redirect } from '../../index.js';
 
 function handleFilterChange(e) {
 	redirect(`/example/people?filter=${e.detail.value}`);

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+export { ContextReactor, redirect, navigate, registerRoutes, RouterTesting } from './router.js';
+export { RouteReactor } from './RouteReactor.js';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "name": "@brightspace-ui-labs/lit-router",
   "description": "",
-  "main": "router.js",
+  "main": "index.js",
   "repository": "https://github.com/BrightspaceUILabs/router.git",
   "scripts": {
     "lint": "eslint . --ext .js,.html",
@@ -26,6 +26,7 @@
     "access": "public"
   },
   "files": [
+    "index.js",
     "router.js",
     "RouteReactor.js"
   ]

--- a/test/helpers/main-view.js
+++ b/test/helpers/main-view.js
@@ -1,5 +1,5 @@
 import { LitElement } from 'lit';
-import { RouteReactor } from '../../RouteReactor.js';
+import { RouteReactor } from '../../index.js';
 
 class MainView extends LitElement {
 	static get properties() {

--- a/test/helpers/param-query-view.js
+++ b/test/helpers/param-query-view.js
@@ -1,5 +1,5 @@
 import { html, LitElement } from 'lit';
-import { RouteReactor } from '../../RouteReactor.js';
+import { RouteReactor } from '../../index.js';
 
 class ParamQueryView extends LitElement {
 	static get properties() {

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1,7 +1,7 @@
 import './helpers/main-view.js';
 import './helpers/param-query-view.js';
 import { aTimeout, expect, fixture, html, waitUntil } from '@brightspace-ui/testing';
-import { navigate, registerRoutes, RouterTesting } from '../router.js';
+import { navigate, registerRoutes, RouterTesting } from '../index.js';
 import { loader as load1 } from './helpers/route-loader-1.js';
 import { loader as load2 } from './helpers/route-loader-2.js';
 


### PR DESCRIPTION
I found it strange that `RouteReactor` is in a separate export, so this moves everything to a central one. Should be non-breaking if I did this right!