### PR TITLE
Fix initialization issue + Refactor

### DIFF
--- a/RouteReactor.js
+++ b/RouteReactor.js
@@ -1,21 +1,23 @@
 import { _createReducedContext, ContextReactor } from './router.js';
 
-export class RouteReactor extends ContextReactor {
+export class RouteReactor {
 	constructor(host) {
-		super(host, ctx => {
-			const reduced = _createReducedContext(ctx);
+		this.host = host;
 
-			Object.keys(reduced).forEach(ctxKey => {
-				this[ctxKey] = reduced[ctxKey];
-			});
+		this._updateState = this._updateState.bind(this);
+		this._contextReactor = new ContextReactor(host, this._updateState, this._updateState);
+	}
 
-			this.renderView = opts => ctx.view?.(host, opts);
-
-			// this.path = ctx.pathname;
-			// this.params = ctx.params;
-			// this.search = ctx.searchParams;
+	_updateState(ctx) {
+		const reduced = _createReducedContext(ctx);
+		Object.keys(reduced).forEach(ctxKey => {
+			this[ctxKey] = reduced[ctxKey];
 		});
-		this.renderView = () => {};
-		super.init();
+
+		this._view = ctx.view;
+	}
+
+	renderView(opts) {
+		return this._view?.(this.host, opts);
 	}
 }

--- a/observeable.js
+++ b/observeable.js
@@ -1,0 +1,28 @@
+export default class Observable {
+	constructor() {
+		this._observers = new Map();
+		this._hasTriggered = false;
+		this._previousData = null;
+	}
+
+	subscribe(observer) {
+		this._observers.set(observer, observer);
+		if (this._hasTriggered) {
+			observer(this._previousData);
+		}
+	}
+
+	unsubscribe(observer) {
+		this._observers.delete(observer);
+	}
+
+	notify(data) {
+		this._observers.forEach(observer => observer(data));
+		this._hasTriggered = true;
+		this._previousData = data;
+	}
+
+	clear() {
+		this._observers.clear();
+	}
+}


### PR DESCRIPTION
I was running into an issue where the `RouteReactor` was not initializing its context values until after the first update. I couldn't figure out an easy way to fix it without refactoring the whole router, so that's what this PR does.

This change is a bit more substantial in how the router works, so let me know if I need to do more here to get this through or if there's any concerns.

Note: This refactor also fixes the Route order inversion issue in a more natural way. As a result, in order to maintain the opt-in nature of the fix, I had to simulate the issue by manually reversing the route definitions if the `enableRouteOrderFix` option isn't set. This technically isn't the exact same issue, but it should simulate the issue well enough that there's time to fix current implementations with the known workaround.