### PR TITLE
NEX-3361 - check if registerRoutes options is defined

### DIFF
--- a/router.js
+++ b/router.js
@@ -93,7 +93,7 @@ export const registerRoutes = (routes, options) => {
 	if (hasRegistered) throw new Error('May not construct multiple routers.');
 	hasRegistered = true;
 
-	if (!options.enableRouteOrderFix) console.warn('lit-router: The enableRouteOrderFix option is not enabled. This may cause issues with route handling. See here for details: https://github.com/BrightspaceUILabs/router/blob/main/README.md#route-order-inversion-issue');
+	if (!options || (options && !options.enableRouteOrderFix)) console.warn('lit-router: The enableRouteOrderFix option is not enabled. This may cause issues with route handling. See here for details: https://github.com/BrightspaceUILabs/router/blob/main/README.md#route-order-inversion-issue');
 
 	configure(options);
 

--- a/router.js
+++ b/router.js
@@ -93,7 +93,7 @@ export const registerRoutes = (routes, options) => {
 	if (hasRegistered) throw new Error('May not construct multiple routers.');
 	hasRegistered = true;
 
-	if (!options || (options && !options.enableRouteOrderFix)) console.warn('lit-router: The enableRouteOrderFix option is not enabled. This may cause issues with route handling. See here for details: https://github.com/BrightspaceUILabs/router/blob/main/README.md#route-order-inversion-issue');
+	if (!options?.enableRouteOrderFix) console.warn('lit-router: The enableRouteOrderFix option is not enabled. This may cause issues with route handling. See here for details: https://github.com/BrightspaceUILabs/router/blob/main/README.md#route-order-inversion-issue');
 
 	configure(options);
 


### PR DESCRIPTION
[NEX-3361 - [Maintenance] Investigate test failures: D2L Link UI not loading](https://desire2learn.atlassian.net/browse/NEX-3361)

Context:

D2L Link test automation started failing the morning of Dec 10.  An [update](https://github.com/BrightspaceUILabs/router/pull/48/files#diff-a73fe0e0bce14920155c1577b261b025ced6d28bf11c113f8b86cb5f429ee471R96) to `@brightspace-ui-labs/lit-router` was released Dec 9.

![image](https://github.com/user-attachments/assets/b7fffc18-64cb-4923-8dba-5953e6f932e9)

Fix:

Add check for defined.  Issue the warning in either case: `options` is not defined, or `options` is defined but `enableRouteOrderFix` is not.
